### PR TITLE
Add github actions to run Rspec

### DIFF
--- a/.github/workflows/cop.yml
+++ b/.github/workflows/cop.yml
@@ -1,0 +1,23 @@
+name: "Rubocop CI"
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.0
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+
+      - name: Run RSpec tests
+        run: bundle exec rspec


### PR DESCRIPTION
We currently don't run rspec on PRs for this repository. This PR would add github actions to run Rspec.