### PR TITLE
Solidus target version fixes

### DIFF
--- a/lib/rubocop/cop/mixin/target_solidus_version.rb
+++ b/lib/rubocop/cop/mixin/target_solidus_version.rb
@@ -35,6 +35,8 @@ module RuboCop
         super(...)
       end
 
+      private
+
       def affected_solidus_version?
         self.class.targeted_solidus_version?(target_solidus_version)
       end


### PR DESCRIPTION
After merging #39, we decided to apply some fixes to the new module. Mainly, the two main changes are:
- pass all attributes to the `add_offense` method
- make `add_offense` the only public method and rewrite all specs after this update