### PR TITLE
Update the documentation for ERB files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,47 @@ require:
     - rubocop-solidus
 ```
 
-After this simply use the `rubocop` command to start linting.
+
+After this^, simply use the `rubocop` command to start linting your Ruby(`.rb`) files.
+
+### For linting `.erb` files
+
+We recommend to run rubocop solidus cops on ERB files. The simplest method to do this is via
+[erblint](https://github.com/Shopify/erb-lint)
+
+#### Add ERBlint to your Gemfile
+```ruby
+  gem 'erb_lint'
+```
+
+#### Add ERBlint config (`.erb-lint.yml`)
+This is the most basic ERBlint config that can be used to run all and only the Solidus cops in any project
+```yaml
+---
+EnableDefaultLinters: false
+linters:
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+    only:
+      - Solidus
+```
+
+#### To run ERBlint for all ERB files
+```bash
+# From project directory
+bundle exec erblint .
+```
+
+#### To run autocorrect on ERB files
+Any cop that supports autocorrect for rubocop implicitly supports autocorrect
+for ERB files as well.
+```bash
+# From project directory
+bundle exec erblint -a .
+```
 
 ## Creating new cops
 


### PR DESCRIPTION
## Summary

We found a way to run solidus cops on ERB files
using ERBlint.
However, we don't want the user of this gem to force another gem so this commits adds the documentation how gem users can configure it themselves

**Fixes:** https://linear.app/nebulab-retainers/issue/RET-49/solidus-erblint

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
