### PR TITLE
ruby-2.6-support: Avoid clobbering for SpreeTDeprecated cop

### DIFF
--- a/lib/rubocop/cop/solidus/spree_t_deprecated.rb
+++ b/lib/rubocop/cop/solidus/spree_t_deprecated.rb
@@ -44,6 +44,7 @@ module RuboCop
       #
       class SpreeTDeprecated < Base
         extend AutoCorrector
+        include IgnoredNode
         MSG = 'Use I18n.t instead of Spree.t which has been deprecated in future versions.'
 
         RESTRICT_ON_SEND = %i[t].freeze
@@ -58,8 +59,11 @@ module RuboCop
           return unless spree_t?(node).include?(:Spree)
 
           add_offense(node) do |corrector|
+            next if part_of_ignored_node?(node)
+
             corrector.replace(node, corrected_statement(node))
           end
+          ignore_node(node)
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/spec/rubocop/cop/solidus/spree_t_deprecated_spec.rb
+++ b/spec/rubocop/cop/solidus/spree_t_deprecated_spec.rb
@@ -91,6 +91,20 @@ RSpec.describe RuboCop::Cop::Solidus::SpreeTDeprecated, :config do
         I18n.t(:solidus_store, scope: [:custom_scope], email: params[:email])
       RUBY
     end
+
+    context 'when nested correction' do
+      it 'registers an offense when using `#bad_method`' do
+        expect_offense(<<~RUBY)
+          Spree.t(:solidus_store, resource: Spree.t(:test))
+                                            ^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          I18n.t(:solidus_store, scope: :spree, resource: I18n.t(:test, scope: :spree))
+        RUBY
+      end
+    end
   end
 
   describe 'first argument is a string' do
@@ -182,6 +196,20 @@ RSpec.describe RuboCop::Cop::Solidus::SpreeTDeprecated, :config do
       expect_no_offenses(<<~RUBY)
         I18n.t('solidus_store', scope: [:custom_scope], email: params[:email])
       RUBY
+    end
+
+    context 'when nested correction' do
+      it 'registers an offense when using `#bad_method`' do
+        expect_offense(<<~RUBY)
+          Spree.t(:solidus_store, resource: Spree.t(:test))
+                                            ^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          I18n.t(:solidus_store, scope: :spree, resource: I18n.t(:test, scope: :spree))
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
**Description**

Getting this error when running `rubocop -a`
<img width="1167" alt="Screenshot 2023-10-12 at 17 58 35" src="https://github.com/solidusio/rubocop-solidus/assets/43698511/dc572870-fce5-4963-9a6b-b8600c8a405e">

we see this error when we have a nested correction, for example : 

```rb
Spree.t(:test, resource: Spree.t(:test))
```
To avoid this error, according to the [Rubocop docs](https://docs.rubocop.org/rubocop/development.html#preventing-clobbering) :
The corrector detects and prevents correcting overlapping nodes, to prevent one correction from clobbering another. Supporting nested corrections is done by taking multiple passes, and skipping corrections for nested nodes. This can be implemented using the IgnoredNode module 
This change works because correcting a file is implemented by repeating investigation and correction until the file no longer requires correction, meaning all nested nodes will eventually be processed.

-----------------

**Severity:**

* [ ] - info
* [ ] - refactor
* [ ] - convention (default)
* [ ] - warning
* [X] - error
* [ ] - fatal

-----------------

**Wrong Code**

```rb
Spree.t(:test, resource: Spree.t(:test))
```

**Correct Code**

```rb
I18n.t(:test, scope: :spree, resource: I18n.t(:test, scope: :spree))
```

-----------------

**Solidus PR Link:** # Replace with link to Solidus PR where the change has been made.

-----------------

**Before submitting the PR make sure the following are checked:**

* [x] The PR relates to *only* one cop with a clear title and description.
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Ran and ensured all tests are passing on a development environment.
* [ ] If this is a new cop, added an entry for the cop on `/config/default.yml`
* [ ] Updated Changelog
