### PR TITLE
Safa/restore discounted amount deprecated cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### New features
 
 * [#25](https://github.com/solidusio/rubocop-solidus/issues/25): Add solidus/tax_category_deprecated warning cop. ([@safafa][])
+* [#31](https://github.com/solidusio/rubocop-solidus/issues/31): Add discounted amount deprecated warning cop. ([@safafa][])
+
 ### Bug fixes
 
 * [#53](https://github.com/solidusio/rubocop-solidus/pull/53): Change spree_default_credit_card_deperecated cop severity to warning. ([@safafa][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -14,6 +14,12 @@ Solidus/ClassEvalDecorator:
   VersionAdded: '0.1'
   Reference: 'https://github.com/solidusio/rubocop-solidus/issues/21'
 
+Solidus/DiscountedAmountDeprecated:
+  Description: 'Checks if .discounted_amount is being used and suggest using .total_before_tax instead.'
+  Enabled: true
+  VersionAdded: '<<next>>'
+  Reference: 'https://github.com/solidusio/rubocop-solidus/issues/31'
+
 Solidus/ExistingCardIdDeprecated:
   Description: 'Checks if existing_card_id is being used and suggest using wallet_payment_source_id instead'
   Enabled: true

--- a/docs/cops_solidus.md
+++ b/docs/cops_solidus.md
@@ -35,6 +35,28 @@ end
 
 * [https://github.com/solidusio/rubocop-solidus/issues/21](https://github.com/solidusio/rubocop-solidus/issues/21)
 
+## Solidus/DiscountedAmountDeprecated
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged | Required Solidus Version
+--- | --- | --- | --- | --- | ---
+Enabled | Yes | No | <<next>> | - | 2.4
+
+This cop finds .discounted_amount occurrences and suggest using .total_before_tax instead.
+
+### Examples
+
+```ruby
+# bad
+line_item.discounted_amount
+
+# good
+line_item.total_before_tax
+```
+
+### References
+
+* [https://github.com/solidusio/rubocop-solidus/issues/31](https://github.com/solidusio/rubocop-solidus/issues/31)
+
 ## Solidus/ExistingCardIdDeprecated
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged | Required Solidus Version

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ In the following sections, you will find all available cops:
 #### Department [Solidus](cops_solidus.md)
 
 * [Solidus/ClassEvalDecorator](cops_solidus.md#solidusclassevaldecorator)
+* [Solidus/DiscountedAmountDeprecated](cops_solidus.md#solidusdiscountedamountdeprecated)
 * [Solidus/ExistingCardIdDeprecated](cops_solidus.md#solidusexistingcardiddeprecated)
 * [Solidus/ReimbursementHookDeprecated](cops_solidus.md#solidusreimbursementhookdeprecated)
 * [Solidus/SpreeCalculatorFreeShippingDeprecated](cops_solidus.md#solidusspreecalculatorfreeshippingdeprecated)

--- a/lib/rubocop/cop/solidus/discounted_amount_deprecated.rb
+++ b/lib/rubocop/cop/solidus/discounted_amount_deprecated.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Solidus
+      # This cop finds .discounted_amount occurrences and suggest using .total_before_tax instead.
+      #
+      # @example
+      #
+      #   # bad
+      #   line_item.discounted_amount
+      #
+      #   # good
+      #   line_item.total_before_tax
+      #
+      #
+      class DiscountedAmountDeprecated < Base
+        include TargetSolidusVersion
+        minimum_solidus_version 2.4
+
+        MSG = 'Use `.total_before_tax` instead of `.discounted_amount`.'
+
+        def_node_matcher :bad_method?, <<~PATTERN
+          (send ... :discounted_amount)
+        PATTERN
+
+        def on_send(node)
+          return unless bad_method?(node)
+
+          add_offense(node, severity: :warning)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/solidus_cops.rb
+++ b/lib/rubocop/cop/solidus_cops.rb
@@ -3,6 +3,7 @@
 require_relative 'mixin/target_solidus_version'
 
 require_relative 'solidus/class_eval_decorator'
+require_relative 'solidus/discounted_amount_deprecated'
 require_relative 'solidus/existing_card_id_deprecated'
 require_relative 'solidus/reimbursement_hook_deprecated'
 require_relative 'solidus/spree_calculator_free_shipping_deprecated'

--- a/spec/rubocop/cop/solidus/discounted_amount_deprecated_spec.rb
+++ b/spec/rubocop/cop/solidus/discounted_amount_deprecated_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Solidus::DiscountedAmountDeprecated, :config do
+  it 'registers an offense when using .discounted_amount' do
+    expect_offense(<<~RUBY)
+      line_item.discounted_amount
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `.total_before_tax` instead of `.discounted_amount`.
+    RUBY
+  end
+
+  it 'does not register an offense when using .total_before_tax' do
+    expect_no_offenses(<<~RUBY)
+      line_item.total_before_tax
+    RUBY
+  end
+end


### PR DESCRIPTION
**Description**

This PR restores solidus/discounted_amount as a warning cop  
issue [31](https://github.com/solidusio/rubocop-solidus/issues/31)

-----------------

**Severity:**

* [ ] - info
* [ ] - refactor
* [ ] - convention (default)
* [x] - warning
* [ ] - error
* [ ] - fatal

-----------------

**Wrong Code**

```rb
line_item.discounted_amount
```

**Correct Code**

```rb
line_item.total_before_tax
```

-----------------

https://github.com/solidusio/solidus/commit/5d614197dc259dba069cde6fda5216675c04f96d

-----------------

**Before submitting the PR make sure the following are checked:**

* [x] The PR relates to *only* one cop with a clear title and description.
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Ran and ensured all tests are passing on a development environment.
* [x] If this is a new cop, added an entry for the cop on `/config/default.yml`
* [x] Updated Changelog
