### PR TITLE
Change spree_default_credit_card_deperecated cop severity to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### New features
 
 * [#25](https://github.com/solidusio/rubocop-solidus/issues/25): Add solidus/tax_category_deprecated warning cop. ([@safafa][])
+### Bug fixes
+
+* [#53](https://github.com/solidusio/rubocop-solidus/pull/53): Change spree_default_credit_card_deperecated cop severity to warning. ([@safafa][])
 
 ## 0.2.0 (2023-11-02)
 

--- a/docs/cops_solidus.md
+++ b/docs/cops_solidus.md
@@ -164,7 +164,7 @@ Spree::Calculator::PriceSack
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged | Required Solidus Version
 --- | --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 0.1 | - | 2.2
+Enabled | Yes | No | 0.1 | - | 2.2
 
 This cop finds user.default_credit_card suggest using user.wallet.default_wallet_payment_source.
 

--- a/lib/rubocop/cop/solidus/spree_default_credit_card_deprecated.rb
+++ b/lib/rubocop/cop/solidus/spree_default_credit_card_deprecated.rb
@@ -14,7 +14,6 @@ module RuboCop
       #   user.wallet.default_wallet_payment_source
       #
       class SpreeDefaultCreditCardDeprecated < Base
-        extend AutoCorrector
         include TargetSolidusVersion
         minimum_solidus_version 2.2
 
@@ -27,9 +26,7 @@ module RuboCop
         def on_send(node)
           return unless default_credit_card?(node)
 
-          add_offense(node) do |corrector|
-            corrector.replace(node, node.source.gsub('default_credit_card', 'wallet.default_wallet_payment_source'))
-          end
+          add_offense(node, severity: :warning)
         end
       end
     end


### PR DESCRIPTION
**Description**

We need to update this cop severity to a warning as mentioned in this [issue](https://github.com/solidusio/rubocop-solidus/issues/53)


-----------------

**Severity:**

* [ ] - info
* [ ] - refactor
* [ ] - convention (default)
* [x] - warning
* [ ] - error
* [ ] - fatal

-----------------

**Wrong Code**

```rb
 user.default_credit_card
```

**Correct Code**

```rb
 user.wallet.default_wallet_payment_source
```

-----------------

**Solidus PR Link:** # Replace with link to Solidus PR where the change has been made.

-----------------

**Before submitting the PR make sure the following are checked:**

* [x] The PR relates to *only* one cop with a clear title and description.
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran and ensured all tests are passing on a development environment.
* [ ] If this is a new cop, added an entry for the cop on `/config/default.yml`
* [x] Updated Changelog
